### PR TITLE
Update NestableTrait.php

### DIFF
--- a/src/NestableTrait.php
+++ b/src/NestableTrait.php
@@ -218,7 +218,9 @@ trait NestableTrait
             list($key, $val) = $value;
             static::$parameters[$method][$key] = $val;
         } elseif (is_array($value)) {
-            static::$parameters[$method][key($value)] = current($value);
+            foreach ($value as $key => $attr) {
+                static::$parameters[$method][$key] = $attr;
+            }
         }
 
         return $this;


### PR DESCRIPTION
Multiple elements passed to attributes array is not getting applied. For example
     
    Category::attr(['name' => 'parent_id', 'class' => 'form-control'])->renderAsDropdown(); 
 
Above line is supposed to take both name and class parameter. But only name is added to select box. Below line on 221 rejects all parameters except first element.

    static::$parameters[$method][key($value)] = current($value);

So if the $value is array, then I'm looping them to add to $paramater variable

    foreach ($value as $key => $attr) {
           static::$parameters[$method][$key] = $attr;
    }