### PR TITLE
Fixed documentation issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ renderAsArray()       | none      | array
 renderAsJson()        | none      | json    
 renderAsHtml()        | none      | html    
 renderAsDropdown()    | none      | dropdown
-renderAsDropdown()    | none      | Listbox
+renderAsMultiple()    | none      | Listbox
 
 Usable methods with output methods
 ---


### PR DESCRIPTION
Changed `renderAsDropdown` for `renderAsMultiple()`. Fixes #49.